### PR TITLE
Order API design

### DIFF
--- a/docs/order.md
+++ b/docs/order.md
@@ -1,0 +1,38 @@
+# Orders Resource API
+
+## Place
+### Request
+`PUT /order/:warehouse_id:/:product_id/:quantity`
+
+### Responses
+
+|type|code|description|
+|-|-|-|
+|success| 200||
+|server error| 500||
+|warehouse not found|412| The spefified warehouse does not exist|
+|product not found| 412 | The ordered product does not exist in the inventory for the speficied warehouse. Takes precidence over insufficient stock. Order fails for all items in order.|
+|insufficient stock| 202 | The ordered products has fewer items in storage than has been ordered. Order fails for all items in the order.|
+
+## Dispatch
+### Request
+`PUT /order/:id/dispatch`
+
+### Responses
+
+|type|code|description|
+|-|-|-|
+|success| 200||
+|server error|500||
+|stock error| 500| The order cannot be fulfilled because there are no longer enough items available. |
+
+## List
+### Request
+`GET /orders`
+
+### Responses
+
+|type|code|description|
+|-|-|-|
+|success| 200|`{['warehouse_id': [{'order_id', 'product_id', number requested, 'status, ''created_at'}]]}`|
+|server error| 500||


### PR DESCRIPTION
Design docs for three order endpoints. 
 - placing an order
 - dispatching an order.
 - listing all orders 

I decided that orders should be able to be placed for arbitrary numbers of items rather than single items at a time. I acknowledge this may provide behaviour that is different from expected. I'd obviously discuss this with a product representative if they were available. The reasoning is that it's redundant to send many requests for many items desired at a given point in time. Doing so risks some requests getting lost and makes it more difficult to track ordered and dispatched items.

I also acknowledge that listing all orders made since the inception of the system has issues. I may modify this later to include an optional 'created since' parameter.

Requesting just for a specific warehouse would also be a nice segmentation of the data.

